### PR TITLE
add blocking for confirm and prompt

### DIFF
--- a/content.js
+++ b/content.js
@@ -3,6 +3,12 @@ var disablerFunction = function () {
     window.alert = function alert(msg) {
         console.log('Hidden Alert: ' + msg);
     };
+    window.confirm = function confirm(msg) {
+    	console.log('Hidden Confirm: ' + msg)
+    };
+    window.prompt = function prompt(msg) {
+    	console.log('Hidden prompt: ' + msg)
+    };
 };
 
 var disablerCode = "(" + disablerFunction.toString() + ")();";


### PR DESCRIPTION
Hello!
In my particular case extension did not blocked some popups, so I've fixed it via adding blocking of prompts and confirms.
It might be useful for somebody else.